### PR TITLE
move default region from us-tirefire-1 to us-west-2 & fix setup.sh

### DIFF
--- a/terraform/scripts/setup.sh
+++ b/terraform/scripts/setup.sh
@@ -16,5 +16,5 @@ rm -rf package/
 tar xvf ${LAMBDA_DIR}/aws_maintenance_lambda-*.tgz
 
 pushd package/
-cp "${CONFIG_FILE}" ./config.json
+cp "../${CONFIG_FILE}" ./config.json
 npm install --production

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,7 +3,7 @@ variable "max_retries" {
 }
 
 variable "aws_region" {
-  default = "us-east-1"
+  default = "us-west-2"
 }
 
 variable "lamba_schedue" {


### PR DESCRIPTION
Credit to @rrxtns for fixing setup.sh - directory was incorrectly nested in the script so terraform apply did not work.

Additionally, I've modified variables.tf to push the lambda to us-west-2 (oregon) instead of us-east-1.

Generally it seems to be a bad plan to bring stuff up in us-east-1 - it has way more reliability issues than other regions. If anything can be region independent, it should not be there.